### PR TITLE
Fixed listing info display boolean bug

### DIFF
--- a/frontend/classes/Listing.js
+++ b/frontend/classes/Listing.js
@@ -8,5 +8,7 @@ export default class Listing {
     this.numBeds = json["numBeds"];
     this.numBaths= json["numBaths"];
     this.mapsUrl = json["maps_url"];
+
+    this.tapped = false;
   }
 }

--- a/frontend/components/ListingMarker.js
+++ b/frontend/components/ListingMarker.js
@@ -3,13 +3,23 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import MapView from 'react-native-maps';
 
 class ListingMarker extends PureComponent {
+
+    tap = () => {
+      this.props.showInfo(this.props.listing, this.props.listing.tapped);
+      if (this.props.listing.tapped) {
+        this.props.listing.tapped = false;
+      } else {
+        this.props.listing.tapped = true;
+      }
+    }
+
     render() {
         return (
           <MapView.Marker
               coordinate={{latitude: this.props.listing.latitude,
               longitude: this.props.listing.longitude}}
               title={this.props.listing.title + ", $" + this.props.listing.price + "/month"}
-              onPress={()=>this.props.showInfo(this.props.listing)}
+              onPress={this.tap}
            />
         );
     }

--- a/frontend/components/UsersMap.js
+++ b/frontend/components/UsersMap.js
@@ -12,20 +12,14 @@ export default class UserMap extends PureComponent {
       openListingPage: false,
   }
 
-  handleMarkerSelect = listing => {
-    if (this.state.openListingPage)
-    {
-      this.setState({selectedListing:listing,
-                     selectedListingModalVisible: true,
-                     openListingPage: false});
+  handleMarkerSelect = (listing, displayModal) => {
+    if (this.state.selectedListing) {
+      this.state.selectedListing.tapped = false;
     }
-    else
-    {
-      this.setState({selectedListing:listing, 
-                     selectedListingModalVisible: false,
-                     openListingPage: true});  
-      this.props.centerMap(listing.latitude, listing.longitude);
-    }
+
+    this.setState({selectedListing:listing,
+                   selectedListingModalVisible: displayModal});
+                   this.props.centerMap(listing.latitude, listing.longitude);
   }
 
   handleCloseModal = () => {


### PR DESCRIPTION
Can click on different markers without having the modal pop up unexpectedly. Done by having a local variable in each listing object that the marker can reference to know whether or not to display the modal when tapped twice. Each time you tap on another marker, it will clear the status of the previously selected marker.

Fixes issue #21 